### PR TITLE
Adding support to benchmark manta buckets APIs

### DIFF
--- a/docker_build/opt/cosbench/autopilot-start-tomcat.sh
+++ b/docker_build/opt/cosbench/autopilot-start-tomcat.sh
@@ -24,9 +24,9 @@ if [ -d /native ]; then
         GC_THREADS=$(echo "8k $DIVIDED 3 + pq" | dc | awk 'function ceil(valor) { return (valor == int(valor) && value != 0) ? valor : int(valor)+1 } { printf "%d", ceil($1) }')
     fi
 
-    TOMCAT_OPTS="-XX:-UseGCTaskAffinity -XX:-BindGCTaskThreadsToCPUs -XX:ParallelGCThreads=${GC_THREADS}"
+    TOMCAT_OPTS="-XX:-UseGCTaskAffinity -XX:-BindGCTaskThreadsToCPUs -XX:ParallelGCThreads=${GC_THREADS} ${JAVA_OPTS}"
 else
-    TOMCAT_OPTS=""
+    TOMCAT_OPTS="${JAVA_OPTS}"
 fi
 
 if [ "$MODE" == "driver" ]; then

--- a/docker_build/opt/cosbench/conf/manta-config.xml
+++ b/docker_build/opt/cosbench/conf/manta-config.xml
@@ -1,33 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <workload name="manta-sample" description="sample benchmark for manta">
 
-  <storage type="manta" config="chunked=false;manta.retries=0;manta.verify_uploads=false;test_type=buckets" />
+    <!-- The test_type parameter can be tweaked to run the cosbench tests for either directories or buckets.
+    Use the value 'dir' to run the tests for directories and the value 'buckets' to run tests for buckets.
+    In the absence of any value the test_type will default to 'dir'
+    -->
+    <storage type="manta" config="chunked=false;manta.retries=0;manta.verify_uploads=false;test_type=buckets" />
 
-  <workflow>
+    <workflow>
 
-    <workstage name="init">
-      <work type="init" workers="1" config="createContainer=true;containers=r(1,2)" />
-    </workstage>
+        <workstage name="init">
+            <work type="init" workers="1" config="createContainer=true;containers=r(1,2)" />
+        </workstage>
 
-    <workstage name="prepare">
-      <work type="prepare" workers="1" config="containers=r(1,2);objects=r(1,50);sizes=c(64)KB" />
-    </workstage>
+        <workstage name="prepare">
+            <work type="prepare" workers="1" config="containers=r(1,2);objects=r(1,50);sizes=c(64)KB" />
+        </workstage>
 
-    <workstage name="main">
-      <work name="main" workers="8" runtime="30">
-        <operation type="read" ratio="80" config="containers=u(1,2);objects=u(1,50)" />
-        <operation type="write" ratio="20" config="containers=u(1,2);objects=u(51,100);sizes=c(64)KB" />
-      </work>
-    </workstage>
+        <workstage name="main">
+            <work name="main" workers="8" runtime="30">
+                <operation type="read" ratio="80" config="containers=u(1,2);objects=u(1,50)" />
+                <operation type="write" ratio="20" config="containers=u(1,2);objects=u(51,100);sizes=c(64)KB" />
+            </work>
+        </workstage>
 
-    <workstage name="cleanup">
-      <work type="cleanup" workers="1" config="containers=r(1,2);objects=r(1,100)" />
-    </workstage>
+        <workstage name="cleanup">
+            <work type="cleanup" workers="1" config="containers=r(1,2);objects=r(1,100)" />
+        </workstage>
 
-    <workstage name="dispose">
-      <work type="dispose" workers="1" config="containers=r(1,2)" />
-    </workstage>
+        <workstage name="dispose">
+            <work type="dispose" workers="1" config="containers=r(1,2)" />
+        </workstage>
 
-  </workflow>
+    </workflow>
 
 </workload>

--- a/docker_build/opt/cosbench/conf/manta-config.xml
+++ b/docker_build/opt/cosbench/conf/manta-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <workload name="manta-sample" description="sample benchmark for manta">
 
-  <storage type="manta" config="chunked=false;manta.retries=0;manta.verify_uploads=false;" />
+  <storage type="manta" config="chunked=false;manta.retries=0;manta.verify_uploads=false;test_type=buckets" />
 
   <workflow>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>8.18</dependency.checkstyle.version>
-        <dependency.java-manta.version>3.4.0</dependency.java-manta.version>
+        <dependency.java-manta.version>3.4.1-SNAPSHOT</dependency.java-manta.version>
         <dependency.slf4j-log4j12.version>1.7.25</dependency.slf4j-log4j12.version>
         <dependency.osgi4.version>1.0</dependency.osgi4.version>
         <dependency.cosbench.version>0.4.1.0</dependency.cosbench.version>

--- a/src/main/java/com/joyent/manta/cosbench/Activator.java
+++ b/src/main/java/com/joyent/manta/cosbench/Activator.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2016, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.joyent.manta.cosbench;
 
 import com.intel.cosbench.log.LogFactory;

--- a/src/main/java/com/joyent/manta/cosbench/MantaStorage.java
+++ b/src/main/java/com/joyent/manta/cosbench/MantaStorage.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2016, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.joyent.manta.cosbench;
 
 import com.intel.cosbench.api.storage.NoneStorage;
@@ -34,6 +41,8 @@ import java.util.Objects;
  * Manta implementation of the COSBench {@link com.intel.cosbench.api.storage.StorageAPI}.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ *
+ * @author <a href="https://github.com/1010sachin">Sachin Gupta</a>
  */
 public class MantaStorage extends NoneStorage {
     /**

--- a/src/main/java/com/joyent/manta/cosbench/MantaStorage.java
+++ b/src/main/java/com/joyent/manta/cosbench/MantaStorage.java
@@ -21,6 +21,7 @@ import com.joyent.manta.exception.MantaClientHttpResponseException;
 import com.joyent.manta.exception.MantaErrorCode;
 import com.joyent.manta.http.MantaHttpHeaders;
 import org.apache.commons.io.input.BoundedInputStream;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,6 +42,16 @@ public class MantaStorage extends NoneStorage {
     private static final String DEFAULT_COSBENCH_BASE_DIR = "stor/cosbench";
 
     /**
+     * Hardcoded bucket in Manta in which all buckets benchmark files are stored.
+     */
+    private static final String DEFAULT_COSBENCH_BUCKETS_PATH = "buckets/";
+
+    /**
+     * Hardcoded bucket in Manta in which all buckets benchmark files are stored.
+     */
+    private static final String DEFAULT_BUCKETS_OBJECT = "objects/";
+
+    /**
      * The default number of maximum HTTP connections at one time to the Manta API.
      */
     private static final int MAX_CONNECTIONS = 1024;
@@ -51,9 +62,9 @@ public class MantaStorage extends NoneStorage {
     private MantaClient client;
 
     /**
-     * The current test directory name.
+     * The current test directory or bucket name.
      */
-    private String currentTestDirectory;
+    private String currentTestDirOrBucket;
 
     /**
      * Number of copies of object to store.
@@ -106,6 +117,11 @@ public class MantaStorage extends NoneStorage {
      */
     private ServerSideMultipartManager serverMultipartManager;
 
+    /**
+     * String representing the type of test either dir or buckets.
+     */
+    private String testType;
+
     @Override
     public void init(final Config config, final Logger logger) {
         logger.debug("Manta client has started initialization");
@@ -124,6 +140,7 @@ public class MantaStorage extends NoneStorage {
                 new SystemSettingsConfigContext(),
                 cosbenchConfig);
 
+        this.testType = cosbenchConfig.testType();
         this.durabilityLevel = cosbenchConfig.getDurabilityLevel();
         this.logging = cosbenchConfig.logging();
         this.sections = cosbenchConfig.getNumberOfSections();
@@ -161,17 +178,8 @@ public class MantaStorage extends NoneStorage {
         try {
             client = new MantaClient(context);
 
-            final String baseDir = Objects.toString(cosbenchConfig.getBaseDirectory(), DEFAULT_COSBENCH_BASE_DIR);
+            initializeClient(cosbenchConfig, context);
 
-            // We rely on COSBench properly cleaning up after itself.
-            currentTestDirectory = String.format("%s/%s", context.getMantaHomeDirectory(), baseDir);
-
-            client.putDirectory(currentTestDirectory, true);
-
-            if (!client.existsAndIsAccessible(currentTestDirectory)) {
-                String msg = "Unable to create base test directory";
-                throw new StorageException(msg);
-            }
         } catch (IOException e) {
             logger.error("Error in initialization", e);
             throw new StorageException(e);
@@ -191,14 +199,63 @@ public class MantaStorage extends NoneStorage {
 
     }
 
+
+    /**
+     * Helper method for initializing cosbench.
+     *
+     * @param cosbenchConfig - The cosbench config.
+     * @param context - The manta config context.
+     * @throws IOException when there is a problem in initializing the manta client
+     */
+    private void initializeClient(final CosbenchMantaConfigContext cosbenchConfig,
+                                  final ChainedConfigContext context) throws IOException {
+        if ("buckets".equals(testType)) {
+            final String bucketsPath = context.getMantaBucketsDirectory();
+            try {
+                client.options(bucketsPath);
+            } catch (MantaClientHttpResponseException e) {
+                if (MantaErrorCode.RESOURCE_NOT_FOUND_ERROR.equals(e.getServerCode())) {
+                    logger.error("Buckets not supported in current Manta",
+                            e.getStatusMessage());
+                    throw new StorageException(e);
+                }
+            }
+            currentTestDirOrBucket = String.format("%s%s%s",
+                    context.getMantaHomeDirectory(), MantaClient.SEPARATOR,
+                    DEFAULT_COSBENCH_BUCKETS_PATH);
+        } else {
+            final String baseDir = Objects.toString(cosbenchConfig.getBaseDirectory(),
+                    DEFAULT_COSBENCH_BASE_DIR);
+            currentTestDirOrBucket = String.format("%s%s%s",
+                    context.getMantaHomeDirectory(), MantaClient.SEPARATOR, baseDir);
+            client.putDirectory(currentTestDirOrBucket, true);
+            if (!client.existsAndIsAccessible(currentTestDirOrBucket)) {
+                String msg = "Unable to create base test directory";
+                throw new StorageException(msg);
+            }
+        }
+    }
+
     @Override
     public void createContainer(final String container, final Config config) {
         if (logging) {
-            logger.info("Performing PUT at /{}", container);
+            if ("buckets".equals(testType)) {
+                logger.info("Performing CREATE bucket at /{}", container);
+            } else {
+                logger.info("Performing PUT dir at /{}", container);
+            }
         }
-
         try {
-            client.putDirectory(directoryOfContainer(container));
+            if ("buckets".equals(testType)) {
+                final String bucketPath = pathOfBaseContainer(container);
+                client.createBucket(bucketPath);
+                if (!client.existsAndIsAccessible(bucketPath)) {
+                    String msg = "Unable to create test bucket";
+                    throw new StorageException(msg);
+                }
+            } else {
+                client.putDirectory(pathOfBaseContainer(container));
+            }
         } catch (Exception e) {
             if (logging) {
                 logger.error("Error creating container", e);
@@ -209,15 +266,24 @@ public class MantaStorage extends NoneStorage {
     @Override
     public void deleteContainer(final String container, final Config config) {
         if (logging) {
-            logger.info("Performing DELETE at /{}", container);
+            if ("buckets".equals(testType)) {
+                logger.info("Performing DELETE bucket at /{}", container);
+            } else {
+                logger.info("Performing DELETE dir at /{}", container);
+            }
         }
 
         try {
-            client.deleteRecursive(directoryOfContainer(container));
+            if ("buckets".equals(testType)) {
+                client.deleteBucket(pathOfBaseContainer(container));
+            } else {
+                client.deleteRecursive(pathOfBaseContainer(container));
+            }
         } catch (MantaClientHttpResponseException e) {
-            if (!e.getServerCode().equals(MantaErrorCode.RESOURCE_NOT_FOUND_ERROR)) {
+            if (!e.getServerCode().equals(MantaErrorCode.RESOURCE_NOT_FOUND_ERROR)
+                    || !e.getServerCode().equals(MantaErrorCode.BUCKET_NOT_FOUND_ERROR)) {
                 if (logging) {
-                    logger.error("Error error deleting object", e);
+                    logger.error("Error deleting container", e);
                 }
                 throw new StorageException(e);
             }
@@ -236,7 +302,12 @@ public class MantaStorage extends NoneStorage {
             final long length,
             final Config config) {
         if (logging) {
-            logger.info("Performing PUT at /{}/{}", container, object);
+            if ("buckets".equals(testType)) {
+                logger.info("Performing PUT bucketobject at /{}/objects/{}",
+                        container, object);
+            } else {
+                logger.info("Performing PUT at /{}/{}", container, object);
+            }
         }
 
         final String path = pathOfObject(container, object);
@@ -267,8 +338,16 @@ public class MantaStorage extends NoneStorage {
             // do things in the right order.
             if (e.getServerCode().equals(MantaErrorCode.DIRECTORY_DOES_NOT_EXIST_ERROR)) {
                 try {
-                    String dir = directoryOfContainer(container);
+                    String dir = pathOfBaseContainer(container);
                     client.putDirectory(dir, true);
+                    client.put(path, data, contentLength, headers, null);
+                } catch (IOException ioe) {
+                    throw new StorageException(ioe);
+                }
+            } else if (e.getServerCode().equals(MantaErrorCode.BUCKET_NOT_FOUND_ERROR)) {
+                try {
+                    String bucketPath = pathOfBaseContainer(container);
+                    client.createBucket(bucketPath);
                     client.put(path, data, contentLength, headers, null);
                 } catch (IOException ioe) {
                     throw new StorageException(ioe);
@@ -334,16 +413,23 @@ public class MantaStorage extends NoneStorage {
     }
 
     @Override
-    public void deleteObject(final String container, final String object, final Config config) {
+    public void deleteObject(final String container, final String object,
+                             final Config config) {
         if (logging) {
-            logger.info("Performing DELETE at /{}/{}", container, object);
+            if ("buckets".equals(testType)) {
+                logger.info("Performing DELETE bucketobject at /{}/objects/{}",
+                        container, object);
+            } else {
+                logger.info("Performing DELETE at /{}/{}", container, object);
+            }
         }
 
         try {
             String path = pathOfObject(container, object);
             client.delete(path);
         } catch (MantaClientHttpResponseException e) {
-            if (!e.getServerCode().equals(MantaErrorCode.RESOURCE_NOT_FOUND_ERROR)) {
+            if (!e.getServerCode().equals(MantaErrorCode.RESOURCE_NOT_FOUND_ERROR)
+            || !e.getServerCode().equals(MantaErrorCode.OBJECT_NOT_FOUND_ERROR)) {
                 if (logging) {
                     logger.error("Error error deleting object", e);
                 }
@@ -366,7 +452,12 @@ public class MantaStorage extends NoneStorage {
 
             if (sections == 1) {
                 if (logging) {
-                    logger.info("Performing GET at /{}/{}", container, object);
+                    if ("buckets".equals(testType)) {
+                        logger.info("Performing GET bucketobject at /{}/objects/{}",
+                                container, object);
+                    } else {
+                        logger.info("Performing GET at /{}/{}", container, object);
+                    }
                 }
                 objectStream = client.getAsInputStream(path);
             } else if (objectSize != null) {
@@ -400,7 +491,12 @@ public class MantaStorage extends NoneStorage {
             final Map<String, String> map,
             final Config config) {
         if (logging) {
-            logger.info("Performing POST at /{}/{}", container, object);
+            if ("buckets".equals(testType)) {
+                logger.info("Performing POST at /{}/objects/{}",
+                        container, object);
+            } else {
+                logger.info("Performing POST at /{}/{}", container, object);
+            }
         }
 
         try {
@@ -423,9 +519,15 @@ public class MantaStorage extends NoneStorage {
     }
 
     @Override
-    protected Map<String, String> getMetadata(final String container, final String object, final Config config) {
+    protected Map<String, String> getMetadata(final String container,
+                                              final String object, final Config config) {
         if (logging) {
-            logger.info("Performing HEAD at /{}/{}", container, object);
+            if ("buckets".equals(testType)) {
+                logger.info("Performing HEAD at /{}/objects/{}",
+                        container, object);
+            } else {
+                logger.info("Performing HEAD at /{}/{}", container, object);
+            }
         }
 
         try {
@@ -460,24 +562,38 @@ public class MantaStorage extends NoneStorage {
     }
 
     /**
-     * Utility method that provides the directory mapping of a container.
+     * Utility method that provides the base path of bucket or dir container.
      *
      * @param container container name
-     * @return directory as string
+     * @return path of the directory or bucket as string
      */
-    private String directoryOfContainer(final String container) {
-        return String.format("%s/%s", currentTestDirectory, container);
+    private String pathOfBaseContainer(final String container) {
+        if ("buckets".equals(testType)) {
+            return String.format("%s%s", currentTestDirOrBucket,
+                    container.toLowerCase().replaceAll("[^a-zA-Z0-9]", StringUtils.EMPTY));
+        } else {
+            return String.format("%s%s%s", currentTestDirOrBucket,
+                    MantaClient.SEPARATOR, container);
+        }
     }
 
     /**
-     * Utility method that provides the directory mapping of an object.
+     * Utility method that provides the directory or bucket mapping of an object.
      *
      * @param container container name
      * @param object object name
      * @return full path to object as string
      */
     private String pathOfObject(final String container, final String object) {
-        String dir = directoryOfContainer(container);
-        return String.format("%s/%s", dir, object);
+        if ("buckets".equals(testType)) {
+            String bucketPath = pathOfBaseContainer(container);
+            return String.format("%s%s%s%s", bucketPath,
+                    MantaClient.SEPARATOR,
+                    DEFAULT_BUCKETS_OBJECT,
+                    object.toLowerCase().replaceAll("[^a-zA-Z0-9]", StringUtils.EMPTY));
+        } else {
+            String dir = pathOfBaseContainer(container);
+            return String.format("%s%s%s", dir, MantaClient.SEPARATOR, object);
+        }
     }
 }

--- a/src/main/java/com/joyent/manta/cosbench/MantaStorageFactory.java
+++ b/src/main/java/com/joyent/manta/cosbench/MantaStorageFactory.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2016, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.joyent.manta.cosbench;
 
 import com.intel.cosbench.api.storage.StorageAPI;

--- a/src/main/java/com/joyent/manta/cosbench/RangeJoiningInputStream.java
+++ b/src/main/java/com/joyent/manta/cosbench/RangeJoiningInputStream.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2016, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.joyent.manta.cosbench;
 
 import com.joyent.manta.client.MantaClient;

--- a/src/main/java/com/joyent/manta/cosbench/config/CosbenchMantaConfigContext.java
+++ b/src/main/java/com/joyent/manta/cosbench/config/CosbenchMantaConfigContext.java
@@ -28,6 +28,11 @@ public class CosbenchMantaConfigContext implements ConfigContext {
     private final Config config;
 
     /**
+     * Default test_type.
+     */
+    private static final String DEFAULT_TEST_TYPE = "dir";
+
+    /**
      * Default constructor that wraps a Cosbench config instance.
      *
      * @param config cosbench config instance
@@ -319,7 +324,14 @@ public class CosbenchMantaConfigContext implements ConfigContext {
      * @return the flag indicating buckets
      */
     public String testType() {
-        return safeGetString("test_type", "Couldn't get test_type setting from COSBench config");
+        String testType = safeGetString("test_type",
+                "Couldn't get test_type setting from COSBench config");
+
+        if (testType == null) {
+            return DEFAULT_TEST_TYPE;
+        }
+
+        return testType;
     }
 
     /**

--- a/src/main/java/com/joyent/manta/cosbench/config/CosbenchMantaConfigContext.java
+++ b/src/main/java/com/joyent/manta/cosbench/config/CosbenchMantaConfigContext.java
@@ -3,6 +3,7 @@ package com.joyent.manta.cosbench.config;
 import com.intel.cosbench.config.Config;
 import com.intel.cosbench.log.LogFactory;
 import com.intel.cosbench.log.Logger;
+import com.joyent.manta.client.MantaClient;
 import com.joyent.manta.config.ConfigContext;
 import com.joyent.manta.config.EncryptionAuthenticationMode;
 import com.joyent.manta.config.MapConfigContext;
@@ -214,6 +215,12 @@ public class CosbenchMantaConfigContext implements ConfigContext {
         }
     }
 
+    @Override
+    public Boolean tlsInsecure() {
+        return safeGetBoolean(MapConfigContext.MANTA_TLS_INSECURE_KEY,
+                "Couldn't get tlsInsecure boolean flag");
+    }
+
     // ========================================================================
     // COSBench Parameters
     // ========================================================================
@@ -307,6 +314,15 @@ public class CosbenchMantaConfigContext implements ConfigContext {
     }
 
     /**
+     * Reads the configuration and finds the test strategy being benchmarked.
+     *
+     * @return the flag indicating buckets
+     */
+    public String testType() {
+        return safeGetString("test_type", "Couldn't get test_type setting from COSBench config");
+    }
+
+    /**
      * Utility method that checks for the presence of Integer values in the
      * COSBench configuration and then returns the value if found.
      *
@@ -395,6 +411,12 @@ public class CosbenchMantaConfigContext implements ConfigContext {
     }
 
     @Override
+    public String getMantaBucketsDirectory() {
+        return ConfigContext.deriveHomeDirectoryFromUser(getMantaUser())
+                + MantaClient.SEPARATOR + "buckets";
+    }
+
+    @Override
     public Boolean isContentTypeDetectionEnabled() {
         return safeGetBoolean(MapConfigContext.MANTA_CONTENT_TYPE_DETECTION_ENABLED_KEY,
                 "Couldn't get content type detection boolean flag");
@@ -431,6 +453,8 @@ public class CosbenchMantaConfigContext implements ConfigContext {
         sb.append(this.getNumberOfSections());
         sb.append("getObjectSize='");
         sb.append(this.getObjectSize());
+        sb.append("testType='");
+        sb.append(this.testType());
         sb.append("}");
 
         return sb.toString();

--- a/src/main/java/com/joyent/manta/cosbench/config/CosbenchMantaConfigContext.java
+++ b/src/main/java/com/joyent/manta/cosbench/config/CosbenchMantaConfigContext.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2016, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.joyent.manta.cosbench.config;
 
 import com.intel.cosbench.config.Config;
@@ -15,6 +22,8 @@ import org.bouncycastle.util.encoders.Base64;
  * connect Cosbench config seamlessly.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ *
+ * @author <a href="https://github.com/1010sachin">Sachin Gupta</a>
  */
 public class CosbenchMantaConfigContext implements ConfigContext {
     /**

--- a/src/test/java/com/joyent/manta/cosbench/RangeJoiningInputStreamTest.java
+++ b/src/test/java/com/joyent/manta/cosbench/RangeJoiningInputStreamTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2016, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.joyent.manta.cosbench;
 
 import org.apache.commons.io.IOUtils;


### PR DESCRIPTION
### Goal
This purpose of this PR is to provide support for benchmarking manta buckets performance, to the existing cosbench-manta adapter code.

### Implementation
The way we achieve the goal is by adding a new cosbench config parameter called ```test_type``` which can take two values either ```dir``` or ```buckets```. Accordingly the existing code has been refactored to run the cosbench benchmark for either directories or buckets.

NOTE: Since the APIs used in the code depend on [java-manta](https://github.com/joyent/java-manta), this PR has been created by using the yet unmerged code from the branch [here](https://github.com/joyent/java-manta/pull/544). Hence, the requested target branch is not ```master``` but rather a test branch. The idea is to merge the ```buckets_test``` branch to the ```master``` once the client SDK code has been merged and a new release version is out.

<img width="1339" alt="Screen Shot 2019-07-31 at 10 46 04 AM" src="https://user-images.githubusercontent.com/37811940/62234909-8c260b00-b380-11e9-8099-89e8a5f6506e.png">